### PR TITLE
Daily mail#27

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -84,3 +84,5 @@ gem 'jp_prefecture'
 gem 'geocoder'
 
 gem "dotenv-rails"
+
+gem 'whenever'

--- a/Gemfile
+++ b/Gemfile
@@ -50,6 +50,8 @@ group :development do
   gem 'rubocop-airbnb'
   gem 'debase'
   gem 'ruby-debug-ide'
+  gem 'letter_opener'
+  gem 'letter_opener_web'
 end
 
 group :test do
@@ -85,4 +87,4 @@ gem 'geocoder'
 
 gem "dotenv-rails"
 
-gem 'whenever'
+gem 'whenever', :require => false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -137,6 +137,14 @@ GEM
       rails-dom-testing (>= 1, < 3)
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
+    launchy (2.5.0)
+      addressable (~> 2.7)
+    letter_opener (1.7.0)
+      launchy (~> 2.2)
+    letter_opener_web (1.4.0)
+      actionmailer (>= 3.2)
+      letter_opener (~> 1.0)
+      railties (>= 3.2)
     listen (3.1.5)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
@@ -365,6 +373,8 @@ DEPENDENCIES
   jbuilder (~> 2.5)
   jp_prefecture
   jquery-rails
+  letter_opener
+  letter_opener_web
   listen (>= 3.0.5, < 3.2)
   puma (~> 3.11)
   rails (~> 5.2.2)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -79,6 +79,7 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (~> 1.5)
       xpath (~> 3.2)
+    chronic (0.10.2)
     coderay (1.1.2)
     coffee-rails (4.2.2)
       coffee-script (>= 2.2.0)
@@ -341,6 +342,8 @@ GEM
     websocket-driver (0.7.1)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.4)
+    whenever (1.0.0)
+      chronic (>= 0.6.3)
     xpath (3.2.0)
       nokogiri (~> 1.8)
 
@@ -381,6 +384,7 @@ DEPENDENCIES
   tzinfo-data
   uglifier (>= 1.3.0)
   web-console (>= 3.3.0)
+  whenever
 
 BUNDLED WITH
    2.1.4

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,4 +1,4 @@
 class ApplicationMailer < ActionMailer::Base
-  default from: 'from@example.com'
+  default from: 'hogehoge@example.com'
   layout 'mailer'
 end

--- a/app/mailers/daily_mailer.rb
+++ b/app/mailers/daily_mailer.rb
@@ -1,0 +1,15 @@
+class DailyMailer < ApplicationMailer
+  def daily_mail(user)
+    require "date"
+    @time_now = DateTime.now
+    @user = user
+    mail to: @user.email, subject: 'Daily Mail'
+  end
+
+  def self.send_daily_mail_users
+    users = User.all
+    users.each do |user|
+      DailyMailer.daily_mail(user).deliver_now
+    end
+  end
+end

--- a/app/views/daily_mailer/daily_mail.text.erb
+++ b/app/views/daily_mailer/daily_mail.text.erb
@@ -1,0 +1,3 @@
+<%= @user.name %> 様
+<%= @time_now %>
+<%= user_url(@user) %>

--- a/config/initializers/mail.rb
+++ b/config/initializers/mail.rb
@@ -1,0 +1,17 @@
+if Rails.env.production?
+  ActionMailer::Base.delivery_method = :smtp
+  ActionMailer::Base.smtp_settings = {
+    address: 'smtp.gmail.com',
+    domain: 'gmail.com',
+    port: 587,
+    user_name: 'test@gmail.com',
+    password: 'test',
+    authentication: 'plain',
+    enable_starttls_auto: true
+  }
+elsif Rails.env.development?
+  ActionMailer::Base.default_url_options = { host: 'localhost:3000' }
+  ActionMailer::Base.delivery_method = :letter_opener_web
+else
+  ActionMailer::Base.delivery_method = :test
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -23,4 +23,8 @@ Rails.application.routes.draw do
   root 'home#top'
   get 'home/about'
   get 'searches/search', as: 'search'
+
+  if Rails.env.development?
+    mount LetterOpenerWeb::Engine, at: "/letter_opener"
+  end
 end

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -1,0 +1,14 @@
+# Rails.rootを使用するために必要。なぜなら、wheneverは読み込まれるときにrailsを起動する必要がある
+require File.expand_path(File.dirname(__FILE__) + "/environment")
+# cronを実行する環境変数
+rails_env = ENV['RAILS_ENV'] || :development
+# cronを実行する環境変数をセット
+set :environment, rails_env
+
+# cronのログの吐き出し場所。ここでエラー内容を確認する
+set :output, "#{Rails.root}/log/cron.log"
+
+# 24時間ごとに実行する
+every 1.days, at: '0:00 am' do
+  rake 'daily_mail:send_mail'
+end

--- a/lib/tasks/daily_mail.rake
+++ b/lib/tasks/daily_mail.rake
@@ -1,0 +1,2 @@
+namespace :daily_mail do
+end

--- a/lib/tasks/daily_mail.rake
+++ b/lib/tasks/daily_mail.rake
@@ -1,2 +1,6 @@
 namespace :daily_mail do
+  desc "登録者全員にメールを送る"
+  task send_mail: :environment do
+    DailyMailer.send_daily_mail_users
+  end
 end

--- a/test/mailers/daily_mailer_test.rb
+++ b/test/mailers/daily_mailer_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class DailyMailerTest < ActionMailer::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/mailers/previews/daily_mailer_preview.rb
+++ b/test/mailers/previews/daily_mailer_preview.rb
@@ -1,0 +1,4 @@
+# Preview all emails at http://localhost:3000/rails/mailers/daily_mailer
+class DailyMailerPreview < ActionMailer::Preview
+
+end


### PR DESCRIPTION
# ユーザーに毎日メールを送り付ける機能を追加
* mailer "daily mailer" を追加
* task "daily mail" を追加
* crontab 管理用に gem "whenever" を追加
* 開発環境でメール送付を確認するために gem "letter_opener(_web)" を追加
* schedule で毎日0:00am(日本では9:00am)にメールを送信するように設定